### PR TITLE
Add AI Risk Atlas paper (Bagehorn et al., 2025) — risk taxonomy & gov…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can browse papers by Machine Learning task category, and use hashtags like `
 * [Fair regression: Quantitative definitions and reduction-based algorithms](https://proceedings.mlr.press/v97/agarwal19d.html) (Agarwal et al., 2019) `#Fairness`
 * [Learning Optimal and Fair Decision Trees for Non-Discriminative Decision-Making](https://arxiv.org/abs/1903.10598) (Aghaei et al., 2019) `#Fairness`
 * [Towards the Systematic Reporting of the Energy and Carbon Footprints of Machine Learning](https://jmlr.org/papers/volume21/20-312/20-312.pdf) (Henderson et al., 2020) `#Environment`
+* [AI Risk Atlas: Taxonomy and Tooling for Navigating AI Risks and Resources](https://arxiv.org/abs/2503.05780) (Bagehorn et al., 2025) `#Governance` `#General`
 
 ### AI Incident Databases
 


### PR DESCRIPTION
…ernance tooling

Adds the AI Risk Atlas paper, which introduces a structured taxonomy consolidating AI risks from multiple sources (NIST AI RMF, OWASP LLM Top 10, MIT AI Risk Repository, EU AI Act) and presents Risk Atlas Nexus / AI Atlas Nexus — open-source tooling that uses knowledge graphs for risk identification, prioritization, and compliance automation.

The paper was published on arXiv (2503.05780) with 20 authors from IBM Research, and the system was demonstrated at AAAI 2025 and AAAI 2026. The associated tooling is listed in the OECD AI Catalogue and is part of the AI Alliance Trust & Safety initiative.

Placed under General ML Testing as a cross-cutting governance/risk framework paper.