### PR TITLE
Add Falsify to General ML Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can browse papers by Machine Learning task category, and use hashtags like `
 * [Fair regression: Quantitative definitions and reduction-based algorithms](https://proceedings.mlr.press/v97/agarwal19d.html) (Agarwal et al., 2019) `#Fairness`
 * [Learning Optimal and Fair Decision Trees for Non-Discriminative Decision-Making](https://arxiv.org/abs/1903.10598) (Aghaei et al., 2019) `#Fairness`
 * [Towards the Systematic Reporting of the Energy and Carbon Footprints of Machine Learning](https://jmlr.org/papers/volume21/20-312/20-312.pdf) (Henderson et al., 2020) `#Environment`
+* [Falsify: Pre-registration for ML accuracy claims via SHA-256 hashing](https://github.com/sk8ordie84/falsify) (sk8ordie84, 2026) `#General` `#Reproducibility`
 
 ### AI Incident Databases
 


### PR DESCRIPTION
Adding **Falsify** under "General ML Testing" — a CLI tool that operationalizes pre-registration for ML accuracy claims using SHA-256 hashing over canonical YAML.

The metric, threshold, and dataset hash are committed to git as a hashed manifest *before* training; any silent edit afterwards causes CI to exit 3 and refuse to produce a verdict. The honest amendment path (`lock --force`) writes a new audit entry preserving the previous hash.

Tagged `#General` (broad applicability) and `#Reproducibility` (the core property it cryptographically enforces).

- Repo: https://github.com/sk8ordie84/falsify
- License: MIT
- PyPI: https://pypi.org/project/falsify/
- 90s demo: https://youtu.be/vVZTNeak5PA

Happy to relocate or rephrase per maintainer preference.