### PR TITLE
Add CausalLayer MCP — deterministic AI liability attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,5 @@ You can browse papers by Machine Learning task category, and use hashtags like `
 ## Time Series
 
 [Contributions are welcome 💕](CONTRIBUTING.md)
+
+- [CausalLayer MCP](https://github.com/smq9sn5jck-coder/causallayer-mcp) - Deterministic AI liability attribution for EU AI Act compliance. Anchors every AI decision to an immutable certificate chain without using LLMs.


### PR DESCRIPTION
CausalLayer is an MCP server that provides deterministic AI liability attribution, specifically designed for EU AI Act Article 14/72 compliance.

**Why it fits this list:**
- Deterministic (no LLM in the loop) — every output is reproducible
- Creates immutable audit trails for AI decisions
- Designed for high-risk AI systems under EU AI Act
- Open source (MIT), runs on Cloudflare Workers

Repo: https://github.com/smq9sn5jck-coder/causallayer-mcp
Live: https://faultkey.com