### PR TITLE
Add BGPT REFUTE (scientific critique & epistemic calibration benchmark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,8 @@ You can browse papers by Machine Learning task category, and use hashtags like `
 ## Time Series
 
 [Contributions are welcome 💕](CONTRIBUTING.md)
+
+
+## Benchmarks
+
+- [REFUTE](https://huggingface.co/datasets/BGPT-OFFICIAL/refute) — Apache-2.0 benchmark for scientific critique & epistemic calibration on recent (2025–2026) science summaries. Separates critique skill from calibrated truthfulness (falsification, limitations, overclaims, missing-evidence refusal, confidence calibration, planted-flaw detection). [Leaderboard](https://huggingface.co/spaces/BGPT-OFFICIAL/refute-leaderboard) · [Technical report](https://huggingface.co/datasets/BGPT-OFFICIAL/refute/blob/main/TECHNICAL_REPORT.md) · [Integrators](https://huggingface.co/datasets/BGPT-OFFICIAL/refute/blob/main/INTEGRATORS.md)


### PR DESCRIPTION
Adds [REFUTE](https://huggingface.co/datasets/BGPT-OFFICIAL/refute), an Apache-2.0 benchmark testing whether models critique recent science summaries with calibrated, evidence-grounded judgment. Public leaderboard, technical report, and runnable Inspect AI + lm-eval integrations. Integrator guide: https://huggingface.co/datasets/BGPT-OFFICIAL/refute/blob/main/INTEGRATORS.md