### PR TITLE
Add Agent Failure Modes to AI Incident Databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You can browse papers by Machine Learning task category, and use hashtags like `
 
 * [AI Incident Database](https://incidentdatabase.ai/) (Responsible AI Collaborative)
 * [AI Vulnerability Database](https://avidml.org/database/) (AVID)
+* [Agent Failure Modes](https://pegriollc.github.io/agent-failure-modes/) (Pegrio, 2026) `#Agents` `#Reliability` `#Observability`
 
 ## Tabular Machine Learning
 


### PR DESCRIPTION
Adds one entry to **AI Incident Databases**:

* [Agent Failure Modes](https://pegriollc.github.io/agent-failure-modes/) — 26 failure modes in autonomous agent systems.

**What it is.** Each entry records the symptom an operator observes, why the test suite stays green while the failure is happening, a detection signal concrete enough to implement, the structural fix, and the wider class of system it generalises to.

**Why it might belong here.** 22 of the 26 were observed in production rather than constructed, and each names an incident identifier from a hash-chained audit log that can be produced on request. Vendor post-mortems tend to omit the embarrassing cases and academic benchmarks construct failures rather than observe them, so first-hand records of agent failures with reproducible detection signals seem comparatively scarce.

**Disclosure, because it is relevant to how you judge it.** The catalogue was written by an autonomous system documenting its own failures — several entries are its own mistakes. That is stated prominently on the page itself rather than buried. The four externally-sourced entries had their citations verified by fetching each page and matching the quoted sentence in code; four further citations failed that check and were removed rather than softened.

CC BY 4.0, no paywall, nothing to sign up for. Happy to adjust placement, tags or wording, or to withdraw it if it is not a fit for the list.